### PR TITLE
Simplify .travis.yml according to Travis Rust guide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
 language: rust
-cache: cargo
-
+rust:
+  - stable
+  - beta
+  - nightly
 matrix:
-  include:
-    # The earliest stable Rust version that works
-    - env: TARGET=x86_64-unknown-linux-gnu
-      rust: 1.24.0
-    - env: TARGET=x86_64-unknown-linux-gnu
-      rust: beta
-    - env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
-
-
-notifications:
-  email: false
+  allow_failures:
+    - rust: nightly


### PR DESCRIPTION
Nightly is prone to randomly breaking, I don't think it should break the build (although it currently failing is a bug).