### PR TITLE
Store timestamps as u64.

### DIFF
--- a/src/spotify/model/audio.rs
+++ b/src/spotify/model/audio.rs
@@ -77,7 +77,7 @@ pub struct AudioAnalysisMeta {
     pub platform: String,
     pub detailed_status: String,
     pub status_code: i32,
-    pub timestamp: u32,
+    pub timestamp: u64,
     pub analysis_time: f32,
     pub input_process: String,
 }

--- a/src/spotify/model/context.rs
+++ b/src/spotify/model/context.rs
@@ -23,7 +23,7 @@ pub struct FullPlayingContext {
     pub repeat_state: RepeatState,
     pub shuffle_state: bool,
     pub context: Option<Context>,
-    pub timestamp: u32,
+    pub timestamp: u64,
     pub progress_ms: Option<u32>,
     pub is_playing: bool,
     pub item: Option<FullTrack>,
@@ -35,7 +35,7 @@ pub struct FullPlayingContext {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimplifiedPlayingContext {
     pub context: Option<Context>,
-    pub timestamp: u32,
+    pub timestamp: u64,
     pub progress_ms: Option<u32>,
     pub is_playing: bool,
     pub item: Option<FullTrack>,

--- a/src/spotify/model/playing.rs
+++ b/src/spotify/model/playing.rs
@@ -9,7 +9,7 @@ use super::track::SimplifiedTrack;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Playing {
     pub context: Option<Context>,
-    pub timestamp: u32,
+    pub timestamp: u64,
     pub progress_ms: Option<u32>,
     pub is_playing: bool,
     pub item: Option<FullTrack>,


### PR DESCRIPTION
Closes #2. I guess Spotify started sending timestamps in milliseconds :)