### PR TITLE
Fix failing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "rspotify"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/spotify/oauth2.rs
+++ b/src/spotify/oauth2.rs
@@ -336,10 +336,9 @@ impl SpotifyOAuth {
     }
     /// Parse the response code in the given response url
     pub fn parse_response_code(&self, url: &mut str) -> Option<String> {
-        let tokens: Vec<&str> = url.split("?code=").collect();
-        let strings: Vec<&str> = tokens[1].split('&').collect();
-        let code = strings[0];
-        Some(code.to_owned())
+        url.split("?code=").nth(1)
+            .and_then(|strs| strs.split('&').next())
+            .map(|s| s.to_owned())
     }
     /// Gets the URL to use to authorize this app
     pub fn get_authorize_url(&self, state: Option<&str>, show_dialog: Option<bool>) -> String {

--- a/src/spotify/senum.rs
+++ b/src/spotify/senum.rs
@@ -7,7 +7,7 @@ pub enum AlbumType {
     Album,
     Single,
     AppearsOn,
-    Compilcation,
+    Compilation,
 }
 impl AlbumType {
     pub fn from_str(s: &str) -> Option<AlbumType> {
@@ -15,7 +15,7 @@ impl AlbumType {
             "album" => Some(AlbumType::Album),
             "single" => Some(AlbumType::Single),
             "appears_on" => Some(AlbumType::AppearsOn),
-            "compilation" => Some(AlbumType::Compilcation),
+            "compilation" => Some(AlbumType::Compilation),
             _ => None,
         }
     }
@@ -24,7 +24,7 @@ impl AlbumType {
             AlbumType::Album => "album",
             AlbumType::Single => "single",
             AlbumType::AppearsOn => "appears_on",
-            AlbumType::Compilcation => "compilation",
+            AlbumType::Compilation => "compilation",
         }
     }
 }
@@ -34,7 +34,7 @@ impl fmt::Debug for AlbumType {
             AlbumType::Album => write!(f, "album"),
             AlbumType::Single => write!(f, "single"),
             AlbumType::AppearsOn => write!(f, "appears_on"),
-            AlbumType::Compilcation => write!(f, "compilation"),
+            AlbumType::Compilation => write!(f, "compilation"),
         }
     }
 }


### PR DESCRIPTION
I fixed a few issues that were preventing the tests from passing:

- GET requests with a body are rejected by Spotify with a 400 response - even `{}`
- If the argument to `parse_response_code` is an empty string, the function panics
- A typo in "compilation" causes deserialisation to fail

Cargo also keeps trying to update the version in `Cargo.lock` to 0.1.2, so I commited that too :)

Thanks a lot for this library, it has saved me a lot of time! :100: 