### PR TITLE
[feat] add debug and clone derives to spotify client and credentials

### DIFF
--- a/src/spotify/client.rs
+++ b/src/spotify/client.rs
@@ -38,6 +38,7 @@ lazy_static! {
     pub static ref CLIENT: Client = Client::new();
 }
 /// Spotify API object
+#[derive(Debug, Clone)]
 pub struct Spotify {
     pub prefix: String,
     pub access_token: Option<String>,

--- a/src/spotify/oauth2.rs
+++ b/src/spotify/oauth2.rs
@@ -21,6 +21,7 @@ use std::fs::OpenOptions;
 use super::util::{convert_map_to_string, datetime_to_timestamp, generate_random_string};
 
 /// Client credentials object for spotify
+#[derive(Debug, Clone)]
 pub struct SpotifyClientCredentials {
     pub client_id: String,
     pub client_secret: String,


### PR DESCRIPTION
This PR adds the `Debug` and `Clone` derives to `Spotify` and `SpotifyClientCredentials`.

Not sure whether we should add Serialize and Deserialize too.