### PR TITLE
OAuth get_authorize_url fixes

### DIFF
--- a/src/spotify/oauth2.rs
+++ b/src/spotify/oauth2.rs
@@ -350,6 +350,8 @@ impl SpotifyOAuth {
         payload.insert("scope", &self.scope);
         if let Some(state) = state {
             payload.insert("state", state);
+        } else {
+            payload.insert("state", &self.state);
         }
         if let Some(show_dialog) = show_dialog {
             if show_dialog {

--- a/src/spotify/oauth2.rs
+++ b/src/spotify/oauth2.rs
@@ -352,7 +352,7 @@ impl SpotifyOAuth {
             payload.insert("state", state);
         }
         if show_dialog.is_some() {
-            payload.insert("show_diaload", "true");
+            payload.insert("show_dialog", "true");
         }
 
         let query_str = convert_map_to_string(&payload);

--- a/src/spotify/oauth2.rs
+++ b/src/spotify/oauth2.rs
@@ -351,8 +351,10 @@ impl SpotifyOAuth {
         if let Some(state) = state {
             payload.insert("state", state);
         }
-        if show_dialog.is_some() {
-            payload.insert("show_dialog", "true");
+        if let Some(show_dialog) = show_dialog {
+            if show_dialog {
+                payload.insert("show_dialog", "true");
+            }
         }
 
         let query_str = convert_map_to_string(&payload);


### PR DESCRIPTION
I've made a few changes to the get_authorize_url function so that it better matches the spotipy implementation. I believe this was the intention here but it had a few lines in need of improvement.

The changes are:
- show_diaload changed to show_dialog. I believe this is a typo
- state parameter falls back to self.state if None
- show_dialog value is set before setting to "true" in parameters

I can split these changes up into multiple pull requests if necessary.