### PR TITLE
Changes to Spotify.user_playlist and Spotify.playlist methods

### DIFF
--- a/examples/current_user_saved_tracks_delete.rs
+++ b/examples/current_user_saved_tracks_delete.rs
@@ -42,7 +42,7 @@ fn main() {
                 Ok(_) => {
                     println!("saved tracks delete successful");
                 }
-                Err(_) => eprintln!("saved traks delete failed"),
+                Err(_) => eprintln!("saved tracks delete failed"),
 
             }
         }

--- a/examples/playlist.rs
+++ b/examples/playlist.rs
@@ -1,0 +1,43 @@
+extern crate rspotify;
+
+use rspotify::spotify::client::Spotify;
+use rspotify::spotify::util::get_token;
+use rspotify::spotify::oauth2::{SpotifyClientCredentials, SpotifyOAuth};
+
+fn main() {
+    // Set client_id and client_secret in .env file or
+    // export CLIENT_ID="your client_id"
+    // export CLIENT_SECRET="secret"
+    // export REDIRECT_URI=your-direct-uri
+
+    // Or set client_id, client_secret,redirect_uri explictly
+    // let oauth = SpotifyOAuth::default()
+    //     .client_id("this-is-my-client-id")
+    //     .client_secret("this-is-my-client-secret")
+    //     .redirect_uri("http://localhost:8888/callback")
+    //     .build();
+
+    let mut spotify_oauth = SpotifyOAuth::default().build();
+    match get_token(&mut spotify_oauth){
+        Some(token_info) => {
+            let client_credential = SpotifyClientCredentials::default()
+                .token_info(token_info)
+                .build();
+
+            // Or set client_id and client_secret explictly
+            // let client_credential = SpotifyClientCredentials::default()
+            //     .client_id("this-is-my-client-id")
+            //     .client_secret("this-is-my-client-secret")
+            //     .build();
+            let spotify = Spotify::default()
+                .client_credentials_manager(client_credential)
+                .build();
+            let playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
+            let playlists = spotify.playlist(&playlist_id, None, None);
+            println!("{:?}", playlists);
+
+        }
+        None => println!("auth failed"),
+    };
+
+}

--- a/examples/user_playlist.rs
+++ b/examples/user_playlist.rs
@@ -34,7 +34,7 @@ fn main() {
                 .build();
             let user_id = "spotify";
             let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
-            let playlists = spotify.user_playlist(user_id, Some(&mut playlist_id), None);
+            let playlists = spotify.user_playlist(user_id, Some(&mut playlist_id), None, None);
             println!("{:?}", playlists);
 
         }

--- a/src/spotify/client.rs
+++ b/src/spotify/client.rs
@@ -480,19 +480,25 @@ impl Spotify {
         self.convert_result::<PublicUser>(&result.unwrap_or_default())
     }
 
-    //TODO: fields
     ///[get playlist](https://developer.spotify.com/documentation/web-api/reference/playlists/get-playlist/)
     ///Get full details about Spotify playlist
     ///Parameters:
     ///- playlist_id - the id of the playlist
     ///- market - an ISO 3166-1 alpha-2 country code.
-    pub fn playlist(&self, playlist_id: &str, market: Option<Country>) -> Result<FullPlaylist, failure::Error> {
+    pub fn playlist(&self,
+                    playlist_id: &str,
+                    fields: Option<&str>,
+                    market: Option<Country>) -> Result<FullPlaylist, failure::Error> {
         let mut params = HashMap::new();
+        if let Some(_fields) = fields {
+            params.insert("fields".to_owned(), _fields.to_string());
+        }
         if let Some(_market) = market {
             params.insert("market".to_owned(), _market.as_str().to_owned());
         }
 
-        let url = format!("playlists/{}", playlist_id);
+        let plid = self.get_id(Type::Playlist, playlist_id);
+        let url = format!("playlists/{}", plid);
         let result = self.get(&url, &mut params);
         self.convert_result::<FullPlaylist>(&result.unwrap_or_default())
     }
@@ -545,11 +551,15 @@ impl Spotify {
     pub fn user_playlist(&self,
                          user_id: &str,
                          playlist_id: Option<&mut str>,
-                         fields: Option<&str>)
+                         fields: Option<&str>,
+                         market: Option<Country>)
                          -> Result<FullPlaylist, failure::Error> {
         let mut params = HashMap::new();
         if let Some(_fields) = fields {
             params.insert("fields".to_owned(), _fields.to_string());
+        }
+        if let Some(_market) = market {
+            params.insert("market".to_owned(), _market.as_str().to_owned());
         }
         match playlist_id {
             Some(_playlist_id) => {

--- a/tests/test_with_credential.rs
+++ b/tests/test_with_credential.rs
@@ -186,7 +186,7 @@ fn test_existing_playlist() {
         .client_credentials_manager(client_credential)
         .build();
 
-    let playlist = spotify.playlist("37i9dQZF1DZ06evO45P0Eo", None);
+    let playlist = spotify.playlist("37i9dQZF1DZ06evO45P0Eo", None, None);
     assert!(playlist.is_ok());
 }
 
@@ -198,6 +198,6 @@ fn test_fake_playlist() {
         .client_credentials_manager(client_credential)
         .build();
 
-    let playlist = spotify.playlist("fake_id", None);
+    let playlist = spotify.playlist("fake_id", None, None);
     assert!(!playlist.is_ok());
 }

--- a/tests/test_with_oauth.rs
+++ b/tests/test_with_oauth.rs
@@ -982,7 +982,7 @@ fn test_user_playlist() {
                 .build();
             let user_id = "spotify";
             let mut playlist_id = String::from("59ZbFPES4DQwEjBpWHzrtC");
-            let playlists = spotify.user_playlist(user_id, Some(&mut playlist_id), None);
+            let playlists = spotify.user_playlist(user_id, Some(&mut playlist_id), None, None);
             assert!(playlists.is_ok());
         }
         None => assert!(false),


### PR DESCRIPTION
- Added `fields` parameter to `Spotify.playlist` method.
- Added `market` parameter to `Spotify.user_playlist` method.
- Extract Playlist ID in `Spotify.playlist` before making a call (directly passing `spotify:playlist:59ZbFPES4DQwEjBpWHzrtC`, etc. to `Spotify.playlist` didn't work before).
- Added an example `playlist.rs` for using `Spotify.playlist` method.