### PR TITLE
Updated webbrowser dependency to fix issue on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 url = "1.6.0"
-webbrowser = "0.2.2"
+webbrowser = "0.4.0"
 lazy_static = "1.0"
 failure = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Samray Leung <samrayleung@gmail.com>"]
 name = "rspotify"
-version = "0.2.5"
+version = "0.2.6"
 license = "MIT"
 readme = "README.md"
 description="Spotify API wrapper"


### PR DESCRIPTION
I didn't run every single test as I had to manually allow every test to access my Spotify data but I did that for 10 tests and any test that didn't need the credentials passed too. Pretty sure this doesn't inflict anything else as it will just switch out the open logic for the webbrowser crate.

Closes #30.