### PR TITLE
Fix de-serialization panics for null values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 url = "1.6.0"
-webbrowser = "0.4.0"
+webbrowser = "0.5.0"
 lazy_static = "1.0"
 failure = "0.1"
 

--- a/src/spotify/model/album.rs
+++ b/src/spotify/model/album.rs
@@ -15,24 +15,24 @@ use super::page::Page;
 pub struct SimplifiedAlbum {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub album_group: Option<String>,
-    pub album_type: String,
+    pub album_type: Option<String>,
     pub artists: Vec<SimplifiedArtist>,
     #[serde(skip_serializing_if="Vec::is_empty",default)]
     pub available_markets: Vec<String>,
     pub external_urls: HashMap<String, String>,
-    pub href: String,
-    pub id: String,
+    pub href: Option<String>,
+    pub id: Option<String>,
     pub images: Vec<Image>,
     pub name: String,
-    #[serde(skip_serializing_if="String::is_empty")]
-    pub release_date: String,
-    #[serde(skip_serializing_if="String::is_empty")]
-    pub release_date_precision: String,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub release_date: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+    pub release_date_precision: Option<String>,
     #[serde(skip_serializing_if="Option::is_none")]
     pub restrictions: Option<Restrictions>,
     #[serde(rename = "type")]
     pub _type: Type,
-    pub uri: String,
+    pub uri: Option<String>,
 }
 
 

--- a/src/spotify/model/artist.rs
+++ b/src/spotify/model/artist.rs
@@ -10,12 +10,12 @@ use super::page::CursorBasedPage;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SimplifiedArtist {
     pub external_urls: HashMap<String, String>,
-    pub href: String,
-    pub id: String,
+    pub href: Option<String>,
+    pub id: Option<String>,
     pub name: String,
     #[serde(rename = "type")]
     pub _type: Type,
-    pub uri: String,
+    pub uri: Option<String>,
 }
 
 ///[artist object full](https://developer.spotify.com/web-api/object-model/#artist-object-full)

--- a/src/spotify/model/track.rs
+++ b/src/spotify/model/track.rs
@@ -19,8 +19,9 @@ pub struct FullTrack {
     pub explicit: bool,
     pub external_ids: HashMap<String, String>,
     pub external_urls: HashMap<String, String>,
-    pub href: String,
-    pub id: String,
+    pub href: Option<String>,
+    pub id: Option<String>,
+    pub is_local: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_playable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -62,8 +63,10 @@ pub struct SimplifiedTrack {
     pub duration_ms: u32,
     pub explicit: bool,
     pub external_urls: HashMap<String, String>,
-    pub href: String,
-    pub id: String,
+    #[serde(default)]
+    pub href: Option<String>,
+    pub id: Option<String>,
+    pub is_local: bool,
     pub name: String,
     pub preview_url: Option<String>,
     pub track_number: u32,


### PR DESCRIPTION
See also: https://github.com/samrayleung/rspotify/issues/37

I have also bumped the webbrowser dependency to allow rspotify to be built for *BSD systems.