### PR TITLE
FIx errors when email or birthdate are missing.

### DIFF
--- a/src/spotify/model/user.rs
+++ b/src/spotify/model/user.rs
@@ -23,7 +23,7 @@ pub struct PublicUser {
 ///[private user object](https://developer.spotify.com/web-api/object-model/#user-object-private)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PrivateUser {
-    pub birthdate: NaiveDate,
+    pub birthdate: Option<NaiveDate>,
     pub country: String,
     pub display_name: Option<String>,
     pub email: String,

--- a/src/spotify/model/user.rs
+++ b/src/spotify/model/user.rs
@@ -26,7 +26,7 @@ pub struct PrivateUser {
     pub birthdate: Option<NaiveDate>,
     pub country: String,
     pub display_name: Option<String>,
-    pub email: String,
+    pub email: Option<String>,
     pub external_urls: HashMap<String, String>,
     pub followers: Option<HashMap<String, Option<Value>>>,
     pub href: String,


### PR DESCRIPTION
The `current_user` endpoint was failing for me since both email and birthdate were missing.